### PR TITLE
Add command for switching languages

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,3 +3,4 @@
 
 npm run lint
 npm test
+npm run build

--- a/locales/en/responses.json
+++ b/locales/en/responses.json
@@ -1,4 +1,8 @@
 {
+  "changeLang": {
+    "error": "Select one of the following languages: {{languages}}",
+    "success": "Okay, I'll answer in English from now on."
+  },
   "ping": "Discbot version **{{version}}** | Response time **{{timeTaken}}** ms",
   "sum": {
     "error": "The correct format is **!sum 1 2 3**.",

--- a/locales/en/responses.json
+++ b/locales/en/responses.json
@@ -3,7 +3,7 @@
     "error": "Select one of the following languages: {{languages}}",
     "success": "Okay, I'll answer in English from now on."
   },
-  "ping": "Discbot version **{{version}}** | Response time **{{timeTaken}}** ms",
+  "ping": "Discbot version **{{version}}** | Language **{{language}}** | Response time **{{timeTaken}}** ms",
   "sum": {
     "error": "The correct format is **!sum 1 2 3**.",
     "success": "That makes **{{sum}}**"

--- a/locales/fi/responses.json
+++ b/locales/fi/responses.json
@@ -1,4 +1,8 @@
 {
+  "changeLang": {
+    "error": "Valitse yksi seuraavista kielistä: {{languages}}",
+    "success": "Selvä, vastaan jatkossa suomeksi."
+  },
   "ping": "Discbot versio **{{version}}** | Vasteaika **{{timeTaken}}** ms",
   "sum": {
     "error": "Oikea muoto on **!sum 1 2 3**.",

--- a/locales/fi/responses.json
+++ b/locales/fi/responses.json
@@ -3,7 +3,7 @@
     "error": "Valitse yksi seuraavista kielistä: {{languages}}",
     "success": "Selvä, vastaan jatkossa suomeksi."
   },
-  "ping": "Discbot versio **{{version}}** | Vasteaika **{{timeTaken}}** ms",
+  "ping": "Discbot versio **{{version}}** | Kieli **{{language}}** | Vasteaika **{{timeTaken}}** ms",
   "sum": {
     "error": "Oikea muoto on **!sum 1 2 3**.",
     "success": "Se tekee yhteensä **{{sum}}**"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@babel/core": "^7.13.8",
         "@babel/preset-env": "^7.13.9",
+        "@rollup/plugin-json": "^4.1.0",
         "@types/i18next-fs-backend": "^1.0.0",
         "@types/jest": "^26.0.20",
         "@types/node": "^14.14.31",
@@ -28,7 +29,7 @@
         "dotenv-cli": "^4.0.0",
         "eslint": "^7.21.0",
         "eslint-config-prettier": "^8.1.0",
-        "eslint-plugin-jest": "^24.1.5",
+        "eslint-plugin-jest": "^24.1.7",
         "eslint-plugin-prettier": "^3.3.1",
         "husky": "^5.1.3",
         "inquirer": "^8.0.0",
@@ -1909,6 +1910,41 @@
         "@octokit/openapi-types": "^5.2.0"
       }
     },
+    "node_modules/@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-json/node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-json/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
@@ -2019,6 +2055,12 @@
         "@types/node": "*",
         "@types/responselike": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -4329,9 +4371,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "24.1.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.5.tgz",
-      "integrity": "sha512-FIP3lwC8EzEG+rOs1y96cOJmMVpdFNreoDJv29B5vIupVssRi8zrSY3QadogT0K3h1Y8TMxJ6ZSAzYUmFCp2hg==",
+      "version": "24.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.7.tgz",
+      "integrity": "sha512-p5Dk/Rgiv+ThxguYl96dj7Hqkow09dwSH1G5ALKdREM4pHO1V1xP0N6/myzoquD3z4h+1YPYHzM+g7Fd0xyaXg==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
@@ -13151,6 +13193,34 @@
         "@octokit/openapi-types": "^5.2.0"
       }
     },
+    "@rollup/plugin-json": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
+      "integrity": "sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/pluginutils": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
@@ -13246,6 +13316,12 @@
         "@types/node": "*",
         "@types/responselike": "*"
       }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -15055,9 +15131,9 @@
       "requires": {}
     },
     "eslint-plugin-jest": {
-      "version": "24.1.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.5.tgz",
-      "integrity": "sha512-FIP3lwC8EzEG+rOs1y96cOJmMVpdFNreoDJv29B5vIupVssRi8zrSY3QadogT0K3h1Y8TMxJ6ZSAzYUmFCp2hg==",
+      "version": "24.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.7.tgz",
+      "integrity": "sha512-p5Dk/Rgiv+ThxguYl96dj7Hqkow09dwSH1G5ALKdREM4pHO1V1xP0N6/myzoquD3z4h+1YPYHzM+g7Fd0xyaXg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@babel/core": "^7.13.8",
     "@babel/preset-env": "^7.13.9",
+    "@rollup/plugin-json": "^4.1.0",
     "@types/i18next-fs-backend": "^1.0.0",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.31",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import json from '@rollup/plugin-json';
 import typescript from 'rollup-plugin-typescript2';
 
 export default [
@@ -15,7 +16,7 @@ export default [
     output: [
       { dir: 'dist', format: 'esm', entryFileNames: '[name].mjs', sourcemap: true }
     ],
-    plugins: [typescript({ sourceMap: false })],
+    plugins: [json(), typescript({ sourceMap: false })],
     preserveModules: true
   }
 ];

--- a/scripts/env.mjs
+++ b/scripts/env.mjs
@@ -5,6 +5,17 @@ import inquirer from 'inquirer';
 import path from 'path';
 import defaults from '../src/data/env.json';
 
+const langChoices = [
+  {
+    name: 'English / English',
+    value: 'en'
+  },
+  {
+    name: 'Finnish / Suomi',
+    value: 'fi'
+  }
+];
+
 /**
  * Merges the default values with user input and
  * creates an `.env` file based on the result.
@@ -41,6 +52,13 @@ async function createEnv() {
 async function getAnswers() {
   return inquirer.prompt([
     {
+      choices: langChoices,
+      message: 'Choose a language for the bot',
+      name: 'BOT_LANG',
+      type: 'list',
+      validate: required
+    },
+    {
       message: 'Bot name',
       name: 'BOT_NAME',
       type: 'input',
@@ -53,9 +71,9 @@ async function getAnswers() {
       validate: required
     },
     {
-      message: 'GitHub token (optional)',
+      message: 'GitHub token for creating releases (optional)',
       name: 'GITHUB_TOKEN',
-      type: 'input'
+      type: 'password'
     }
   ]);
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import Discord from 'discord.js';
 import { logger } from '../utils/logger';
+import { commandLang } from './lang';
 import { commandPing } from './ping';
 import { commandSum } from './sum';
 
@@ -13,6 +14,10 @@ type DoCommandProps = {
 async function doCommand({ args, command, message }: DoCommandProps): Promise<void> {
   let performCommand: null | Promise<void> = null;
   switch (command) {
+    case 'lang': {
+      performCommand = commandLang(args, message);
+      break;
+    }
     case 'ping': {
       performCommand = commandPing(message);
       break;

--- a/src/commands/lang.ts
+++ b/src/commands/lang.ts
@@ -1,0 +1,16 @@
+import Discord from 'discord.js';
+import { changeLanguage, i18n } from '../utils/i18n';
+import { logSuccess } from '../utils/logger';
+import { parseLang } from '../utils/parsers';
+
+async function commandLang(args: string[], message: Discord.Message): Promise<void> {
+  const lang = parseLang(args);
+  if (lang) await changeLanguage(lang);
+  const replyMessage = lang
+    ? i18n.t('responses:changeLang.success')
+    : i18n.t('responses:changeLang.error', { languages: i18n.languages.join(', ') });
+  const response = await message.reply(replyMessage);
+  return logSuccess({ message, replyMessage, response });
+}
+
+export { commandLang };

--- a/src/commands/ping.ts
+++ b/src/commands/ping.ts
@@ -3,9 +3,10 @@ import { i18n } from '../utils/i18n';
 import { logSuccess } from '../utils/logger';
 
 async function commandPing(message: Discord.Message): Promise<void> {
+  const { language } = i18n;
   const timeTaken = message.createdTimestamp - Date.now();
   const version = process.env.npm_package_version;
-  const replyMessage = i18n.t('responses:ping', { timeTaken, version });
+  const replyMessage = i18n.t('responses:ping', { language, timeTaken, version });
   const response = await message.reply(replyMessage);
   return logSuccess({ message, replyMessage, response });
 }

--- a/src/data/env.json
+++ b/src/data/env.json
@@ -1,4 +1,5 @@
 {
+  "BOT_LANG": "",
   "BOT_NAME": "",
   "BOT_TOKEN": "",
   "GITHUB_TOKEN": ""

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,11 +1,14 @@
+import dotenv from 'dotenv';
 import i18next, { InitOptions } from 'i18next';
 import Backend, { i18nextFsBackend } from 'i18next-fs-backend';
 import { join } from 'path';
 import { isDebug } from './consts';
 
+dotenv.config();
+
 const i18nBackendOptions: i18nextFsBackend.i18nextFsBackendOptions = {
-  addPath: join(process.env.PWD || '', '../../locales/{{lng}}/{{ns}}.missing.json'),
-  loadPath: join(process.env.PWD || '', '../../locales/{{lng}}/{{ns}}.json')
+  addPath: join(process.env.PWD || '', '/locales/{{lng}}/{{ns}}.missing.json'),
+  loadPath: join(process.env.PWD || '', '/locales/{{lng}}/{{ns}}.json')
 };
 
 const i18nOptions: InitOptions = {
@@ -13,9 +16,10 @@ const i18nOptions: InitOptions = {
   debug: isDebug,
   defaultNS: 'responses',
   fallbackLng: {
-    default: ['en']
+    default: ['en', 'fi']
   },
-  lng: 'fi',
+  lowerCaseLng: true,
+  lng: process.env.BOT_LANG,
   ns: ['responses']
 };
 

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -1,8 +1,11 @@
+import chalk from 'chalk';
 import dotenv from 'dotenv';
 import i18next, { InitOptions } from 'i18next';
 import Backend, { i18nextFsBackend } from 'i18next-fs-backend';
 import { join } from 'path';
 import { isDebug } from './consts';
+import { updateEnv } from './env';
+import { logger } from './logger';
 
 dotenv.config();
 
@@ -27,4 +30,13 @@ i18next.use(Backend).init(i18nOptions);
 
 const i18n = i18next;
 
-export { i18n };
+i18n.on('languageChanged', (lang) => {
+  logger.info('Language changed to:', chalk.yellow(lang));
+  updateEnv('BOT_LANG', lang);
+});
+
+async function changeLanguage(lang: string): Promise<void> {
+  await i18n.changeLanguage(lang);
+}
+
+export { changeLanguage, i18n };

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -1,4 +1,5 @@
 import Discord from 'discord.js';
+import { i18n } from './i18n';
 
 function parseArgs(args: string[]): string[] {
   // Discard empty entries
@@ -13,6 +14,11 @@ function parseBody(body: string, prefix: string): string {
 function parseCommand(args: string[]): string {
   // Return the first command
   return (args.shift() || '').toLowerCase();
+}
+
+function parseLang(args: string[]): string {
+  const potentialLang = (args[0] || '').trim().toLocaleLowerCase();
+  return i18n.languages.includes(potentialLang) ? potentialLang : '';
 }
 
 function parseMessage(
@@ -31,4 +37,4 @@ function parseSum(args: string[]): number {
     .reduce((counter, n) => (counter += n));
 }
 
-export { parseArgs, parseMessage, parseSum };
+export { parseArgs, parseLang, parseMessage, parseSum };


### PR DESCRIPTION
Adds support for switching languages through a message.

## Usage

```
!lang fi
```

Changes the language to Finnish. Typing `!lang` will give a list of available languages.

## Available languages

- English (en)
- Finnish (fi)

## Commits 

- Related 16c6e50cee0e3c1a668eb6328164486c23baa747, 784a54b3ed06e7520fcf978035dd0bcf0ed99c92 and 1da0a5d7d16c7751d1b365cce8987e72336b0cb1

## Issues

- Resolves #1

## Todo
- [x] Add `lang` command
- [x] Create function for switching languages
- [x] Create translations and add responses to locales
- [x] Create parser for languages
- [x] Persist changes when server restarts
