### PR TITLE
Add support for unknown command

### DIFF
--- a/locales/en/responses.json
+++ b/locales/en/responses.json
@@ -7,5 +7,13 @@
   "sum": {
     "error": "The correct format is **!sum 1 2 3**.",
     "success": "That makes **{{sum}}**"
+  },
+  "unknownCommand": {
+    "embed": {
+      "description": "If you'd like to create a proposal for a new feature, you can submit a new issue on GitHub.",
+      "title": "Create a new feature request",
+      "url": "https://github.com/Phoenix2k/discbot/issues/new?labels=feature+request&template=feature_request.md"
+    },
+    "reply": "I'm not sure what {{command}} is supposed to do, but maybe someday in the future I will!"
   }
 }

--- a/locales/en/responses.json
+++ b/locales/en/responses.json
@@ -14,6 +14,6 @@
       "title": "Create a new feature request",
       "url": "https://github.com/Phoenix2k/discbot/issues/new?labels=feature+request&template=feature_request.md"
     },
-    "reply": "I'm not sure what {{command}} is supposed to do, but maybe someday in the future I will!"
+    "reply": "I'm not sure what **{{command}}** is supposed to do, but maybe someday in the future I will!"
   }
 }

--- a/locales/fi/responses.json
+++ b/locales/fi/responses.json
@@ -14,6 +14,6 @@
       "title": "Luo uusi ehdotus",
       "url": "https://github.com/Phoenix2k/discbot/issues/new?labels=feature+request&template=feature_request.md"
     },
-    "reply": "En ole varma mitä {{command}} on tarkoitus tehdä, mutta ehkä joskus tulevaisuudessa tiedän!"
+    "reply": "En ole varma mitä **{{command}}** on tarkoitus tehdä, mutta ehkä joskus tulevaisuudessa tiedän!"
   }
 }

--- a/locales/fi/responses.json
+++ b/locales/fi/responses.json
@@ -7,5 +7,13 @@
   "sum": {
     "error": "Oikea muoto on **!sum 1 2 3**.",
     "success": "Se tekee yhteensä **{{sum}}**"
+  },
+  "unknownCommand": {
+    "embed": {
+      "description": "Jos haluat tehdä ehdotuksen tulevasta featuresta, voit luoda sille issuen GitHubissa.",
+      "title": "Luo uusi ehdotus",
+      "url": "https://github.com/Phoenix2k/discbot/issues/new?labels=feature+request&template=feature_request.md"
+    },
+    "reply": "En ole varma mitä {{command}} on tarkoitus tehdä, mutta ehkä joskus tulevaisuudessa tiedän!"
   }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ import { logger } from '../utils/logger';
 import { commandLang } from './lang';
 import { commandPing } from './ping';
 import { commandSum } from './sum';
+import { commandUnknown } from './unknown';
 
 type DoCommandProps = {
   args: string[];
@@ -28,7 +29,7 @@ async function doCommand({ args, command, message }: DoCommandProps): Promise<vo
     }
     default:
       logger.warn('No command specified for', chalk.yellow(command));
-      return;
+      performCommand = commandUnknown(command, message);
   }
   logger.info('Performing', chalk.yellow(command), 'command …');
   return performCommand;

--- a/src/commands/unknown.ts
+++ b/src/commands/unknown.ts
@@ -1,0 +1,17 @@
+import Discord, { MessageEmbed } from 'discord.js';
+import { i18n } from '../utils/i18n';
+import { logSuccess } from '../utils/logger';
+
+async function commandUnknown(command: string, message: Discord.Message): Promise<void> {
+  const replyMessage = i18n.t('responses:unknownCommand.reply', { command });
+  const embed = new MessageEmbed()
+    .setDescription(i18n.t('responses:unknownCommand.embed.description'))
+    .setTitle(i18n.t('responses:unknownCommand.embed.title'))
+    .setURL(i18n.t('responses:unknownCommand.embed.url'));
+
+  const response = await message.reply(replyMessage);
+  await message.channel.send({ embed });
+  return logSuccess({ message, replyMessage, response });
+}
+
+export { commandUnknown };


### PR DESCRIPTION
Adds support for unknown commands.

```
!something
```

Will result in the following response:

> @Username, Don't know what that does, but maybe someday in the future I will!

Also adds an embed to create an issue on GitHub.

## Todo
- [x] Create translations and add new responses to locales
- [x] Create link to issue using correct template